### PR TITLE
Use transcriptcluster.db instead of probeset.db for ST arrays

### DIFF
--- a/archives/README.md
+++ b/archives/README.md
@@ -1,3 +1,3 @@
-These files are gene conversion matrixes.
+These files are gene conversion matrices.
 
 See more here: https://github.com/AlexsLemonade/identifier-refinery

--- a/build_and_convert.py
+++ b/build_and_convert.py
@@ -170,21 +170,18 @@ ba_sp = {'bovgene10st': 'Bt',
  'zebgene11st': 'Dr',
  'zebrafish': 'Dr'
 }
-probesets = [
+transcriptclusters = [
     "clariomdhuman",
     "hta20",
-    "huex10st",
     "hugene10st",
     "hugene11st",
     "hugene20st",
     "hugene21st",
-    "moex10st",
     "mogene10st",
     "mogene11st",
     "mogene20st",
     "mogene21st",
     "mta10",
-    "raex10st",
     "ragene10st",
     "ragene11st",
     "ragene20st",
@@ -207,8 +204,8 @@ for brainarray, pd in ba_pd.items():
     try:
         tag = "convert/" + brainarray
 
-        if brainarray in probesets:
-            database = brainarray + "probeset"
+        if brainarray in transcriptclusters:
+            database = brainarray + "transcriptcluster"
         else:
             database = brainarray
 


### PR DESCRIPTION
Closes #5. Turns out that those probe ids are correct/the platform design packages followed the same general format. It was the lack of overlap with the mappings in the `probeset.db` package that was the issue. I've moved to using the more "gene-centric" `transcriptcluster.db` packages. Here's what the head of `ragene10st.tsv` looks like now:

PROBEID | ENSEMBL | SYMBOL | ENTREZID | UNIGENE | REFSEQ
-- | -- | -- | -- | -- | --
10918791 | ENSRNOG00000005970 | Lrrc1 | 367113 | Rn.15622 | NM_001014268
10918791 | ENSRNOG00000005970 | Lrrc1 | 367113 | Rn.15622 | NP_001014290
10805165 | ENSRNOG00000051965 | Smad4 | 50554 | Rn.9774 | NM_019275
10805165 | ENSRNOG00000051965 | Smad4 | 50554 | Rn.9774 | NP_062148
10828440 | ENSRNOG00000000471 | B3galt4 | 171079 | Rn.24575 | NM_133553
10828440 | ENSRNOG00000000471 | B3galt4 | 171079 | Rn.24575 | NP_598237
10889331 | ENSRNOG00000059402 | Itgb1bp1 | 298914 | Rn.29469 | NM_001106719
10889331 | ENSRNOG00000059402 | Itgb1bp1 | 298914 | Rn.29469 | NP_001100189
10889331 | ENSRNOG00000059402 | Itgb1bp1 | 298914 | Rn.29469 | XM_006239979
10889331 | ENSRNOG00000059402 | Itgb1bp1 | 298914 | Rn.29469 | XM_006239980

