### PR TITLE
Pin R dependencies

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,23 +1,61 @@
-# Turn warnings into errors because biocLite throws warnings instead
-# of error if it fails to install something.
-options(warn=2)
-options(repos=structure(c(CRAN="https://cloud.r-project.org")))
-options(Ncpus=parallel::detectCores())
+# Pin devtools to version 1.13.6 & install its dependencies
+# devtools is the package we use to install specific versions of other packages
+# see also: https://github.com/AlexsLemonade/refinebio/pull/752
 
-# Install dev packages
-install.packages("devtools")
+# From https://github.com/AlexsLemonade/refinebio/blob/d55616dff8270aa46179a26c8e86318c8535df32/common/install_devtools.R
+
+# Treat warnings as errors, set CRAN mirror, and set parallelization:
+options(warn=2)
+options(repos=structure(c(CRAN="http://lib.stat.cmu.edu/R/CRAN/")))
+
+install_package_version <- function(package_name, version) {
+  # This function install a specific version of a package.
+
+  # However, because the most current version of a package lives in a
+  # different location than the older versions, we have to check where
+  # it can be found.
+  package_tarball <- paste0(package_name, "_", version, ".tar.gz")
+  package_url <- paste0("http://lib.stat.cmu.edu/R/CRAN/src/contrib/", package_tarball)
+
+  # Give CRAN a full minute to timeout since it's not always the most reliable.
+  curl_result <- system(paste0("curl --head --connect-timeout 60 ", package_url), intern=TRUE)
+  if (grepl("404", curl_result[1])) {
+    package_url <- paste0("http://lib.stat.cmu.edu/R/CRAN/src/contrib/Archive/", package_name, "/", package_tarball)
+
+    # Make sure the package actually exists in the archive!
+    curl_result <- system(paste0("curl --head --connect-timeout 120 ", package_url), intern=TRUE)
+    if (grepl("404", curl_result[1])) {
+      stop(paste("Package", package_name, "version", version, "does not exist!"))
+    }
+  }
+
+  install.packages(package_url)
+}
+
+install_package_version("jsonlite", "1.5")
+install_package_version("mime", "0.6")
+install_package_version("curl", "3.2")
+install_package_version("openssl", "1.0.2")
+install_package_version("R6", "2.3.0")
+install_package_version("httr", "1.3.1")
+install_package_version("digest", "0.6.18")
+install_package_version("memoise", "1.1.0")
+install_package_version("whisker", "0.3-2")
+install_package_version("rstudioapi", "0.8")
+install_package_version("git2r", "0.23.0")
+install_package_version("withr", "2.1.2")
+install_package_version("devtools", "1.13.6")
 
 # Use devtools::install_version() to install packages in cran.
 devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
+devtools::install_version('rlang', version='0.2.2')
+devtools::install_version('dplyr', version='0.7.4')
+devtools::install_version('readr', version='1.1.1')
+devtools::install_version('tidyr', version='0.8.2')
 
-# Bioconductor packages, installed by devtools::install_url()
-
-# devtools::install_url() requires biocLite.R
-source('https://bioconductor.org/biocLite.R')
-
-# Tidyverse and related
-install.packages("tidyverse")
+# BiocInstaller, required by devtools::install_url()
+install.packages('https://bioconductor.org/packages/3.6/bioc/src/contrib/BiocInstaller_1.28.0.tar.gz')
 
 # Helper function that installs a list of packages based on input URL
 install_with_url <- function(main_url, packages) {

--- a/R/install_pd.R
+++ b/R/install_pd.R
@@ -4,15 +4,13 @@ install_with_url <- function(main_url, packages) {
          function(pkg) devtools::install_url(paste0(main_url, pkg)))
 }
 
-source("https://bioconductor.org/biocLite.R")
-biocLite(paste0(Sys.getenv("DB"), '.db'))
-biocLite('pd.ht.hg.u133.plus.pm')
-biocLite('pd.ht.mg.430a')
-biocLite("htmg430aprobe")
+BiocInstaller::biocLite(paste0(Sys.getenv("DB"), '.db'))
+BiocInstaller::biocLite('pd.ht.hg.u133.plus.pm')
+BiocInstaller::biocLite('pd.ht.mg.430a')
+BiocInstaller::biocLite("htmg430aprobe")
 
 annotation_url <- 'https://bioconductor.org/packages/3.6/data/annotation/src/contrib/'
 pd_annotation_pkgs <- c(
 	Sys.getenv("PACKAGE")
 )
 install_with_url(annotation_url, pd_annotation_pkgs)
-

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ ./generate_matricies_from_scratch.sh celegans
 
 ## Identifiers
 
-Released assets in this repository are availble under the DOI, `10.5281/zenodo.1322711`, which can be seen on Zenodo [here](https://zenodo.org/record/1322711).
+Released assets in this repository are availble under the DOI, `10.5281/zenodo.1322711`, which can be seen on Zenodo [here](https://zenodo.org/record/1322711). This accession is up to date as of https://github.com/AlexsLemonade/identifier-refinery/commit/cace2849baf2666f21ec32f5eee6208d6ec19294.
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ![](https://i.imgur.com/GphUr2m.png)
 # identifier-refinery [![](https://zenodo.org/badge/DOI/10.5281/zenodo.1322711.svg)](https://zenodo.org/record/1322711)
 
-Tools and assets for easy and reproducable gene identifier conversion.
+Tools and assets for easy and reproducible gene identifier conversion.
 
 ## Methods
 
-This repository is used to build matricies which can convert between different gene identifiers.
+This repository is used to build matrices which can convert between different gene identifiers.
 
-These conversion matricies are built by:
+These conversion matrices are built by:
 
  * Randomly choosing raw CEL files from NCBI GEO for a given platform accession code (in `/cels`)
  * Reading the CEL header and joining Brainarray (e.g., `hgu133plus2hsensgprobe`) and Bioconductor (e.g., `hgu133plus2.db`) (x, y) coordinates
@@ -27,7 +27,7 @@ The `cels` directory contains raw CEL files taken from GEO. The list of supporte
 
 The conversion scripts are run on custom Docker images. 
 
-Two Dockerfiles are provided in this repository - `base` Docker image, which is used to install the quire R dependancies, and the `pd` image, which is used to build the required databases for a given platform.
+Two Dockerfiles are provided in this repository - `base` Docker image, which is used to install the required R dependencies, and the `pd` image, which is used to build the required databases for a given platform.
 
 ### Conversion Scripts
 


### PR DESCRIPTION
Closes #9 and also fixes some typos in the README. Because we don't necessarily want to update the Zenodo accession right now, I've added the commit before this to the README as a note.

Side note: we should keep an eye on the versioning on Zenodo -- there are three version 0.1.0 with the same release date, so it's not clear what zip file is most recent.